### PR TITLE
Add YYLO

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -2939,6 +2939,14 @@
           "slug": "x-note-writer-api"
         },
         {
+          "title": "YYLO",
+          "body": "Command-line orchestrator for coding agents.",
+          "tag": "Open-source",
+          "url": "https://www.yylo.dev?ref=riseofmachine.com",
+          "date-added": "2026-09-09",
+          "slug": "yylo"
+        },
+        {
           "title": "Zen Agents",
           "body": "Build & share custom AI agents for your codebase.",
           "tag": "Freemium",


### PR DESCRIPTION
## What this adds

One new tool entry for **YYLO** in the `developer` category (alphabetical position, after "X Note Writer API"):

```json
{
  "title": "YYLO",
  "body": "Command-line orchestrator for coding agents.",
  "tag": "Open-source",
  "url": "https://www.yylo.dev?ref=riseofmachine.com",
  "date-added": "2026-09-09",
  "slug": "yylo"
}
```

## Why it fits

- **Genuinely AI-powered**: YYLO is an open-source command-line orchestrator for coding agents — it runs repeatable workflows across AI coding agents (Pi / Codex subagents) in isolated git worktrees, with typed task, validation, merge, and release-readiness boundaries. The `body` field is the product's own one-line description, kept factual per the field rules.
- **Live and reachable**: https://www.yylo.dev (MIT-licensed CLI, installable via npm `@yylo/cli`, actively developed daily).
- **Category**: `developer`, beside the terminal/local/open-source band (Open Interpreter, SmythOS, n8n Workflow Builder).

## Verification (per CONTRIBUTING)

- Only `src/data/tools.json` touched (+8/−0, one entry).
- `bun run add-slugs` → `Generated slug for YYLO: yylo` (sorting normalized, no other entries moved).
- `bun run check-data` → `Total tools processed: 1066 · Issues found: 0 · ✅ Data check passed!`
- No duplicate title or URL in the category (checked before adding).

## Disclosure

I'm on the team that builds YYLO (self-submission). This PR was prepared with a coding agent following the "Prompt for agents" workflow in CONTRIBUTING.md, with both checks run locally and passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the YYLO tool to the Developer category.
  * Included a description identifying YYLO as an open-source command-line orchestrator for coding agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->